### PR TITLE
Implement new model/resnet vae

### DIFF
--- a/src/models/components/encoders/ResNet/__init__.py
+++ b/src/models/components/encoders/ResNet/__init__.py
@@ -1,2 +1,3 @@
 from .simple import *
 from .vgg16 import *
+from .vae import *

--- a/src/models/components/encoders/ResNet/vae.py
+++ b/src/models/components/encoders/ResNet/vae.py
@@ -1,0 +1,74 @@
+from typing import Tuple
+import torch
+
+from src.models.components.blocks import ResNetResidualBlock
+
+
+__all__ = [
+    "ResNetVaeEncoder"
+]
+
+class ResNetVaeEncoder(torch.nn.Module):
+    def __init__(self, in_channels: int = 1, out_features: int = 28):
+        super().__init__()
+        blocks = [
+            torch.nn.Conv2d(in_channels, out_channels=256, kernel_size=1),
+            ResNetResidualBlock(in_channels=256, filter_sizes=[1, 3, 1], hidden_dims=[64, 64], out_channels=256),
+            torch.nn.Conv2d(256, 256, kernel_size=3, stride=2, padding=1),
+            ResNetResidualBlock(in_channels=256, filter_sizes=[1, 3, 1], hidden_dims=[64, 64], out_channels=256),
+            torch.nn.Conv2d(256, 256, kernel_size=3, stride=2, padding=1),
+            ResNetResidualBlock(in_channels=256, filter_sizes=[1, 3, 1], hidden_dims=[64, 64], out_channels=256),
+            torch.nn.Conv2d(256, 256, kernel_size=3, stride=2, padding=1),
+            ResNetResidualBlock(in_channels=256, filter_sizes=[1, 3, 1], hidden_dims=[64, 64], out_channels=256),
+            torch.nn.Conv2d(256, 256, kernel_size=1),
+            ResNetResidualBlock(in_channels=256, filter_sizes=[1, 3, 1], hidden_dims=[64, 64], out_channels=256),
+            torch.nn.Conv2d(256, 256, kernel_size=1),
+            ResNetResidualBlock(in_channels=256, filter_sizes=[1, 3, 1], hidden_dims=[64, 64], out_channels=256),
+            torch.nn.Conv2d(256, 256, kernel_size=1),
+            ResNetResidualBlock(in_channels=256, filter_sizes=[1, 3, 1], hidden_dims=[64, 64], out_channels=256),
+            torch.nn.Conv2d(256, 256, kernel_size=1),
+            ResNetResidualBlock(in_channels=256, filter_sizes=[1, 3, 1], hidden_dims=[64, 64], out_channels=256),
+            torch.nn.Conv2d(256, 256, kernel_size=1),
+            ResNetResidualBlock(in_channels=256, filter_sizes=[1, 3, 1], hidden_dims=[64, 64], out_channels=256),
+            torch.nn.Conv2d(256, 256, kernel_size=1),
+        ]
+        self.convs = torch.nn.Sequential(*blocks)
+        blocks = [
+            torch.nn.Linear(in_features=256, out_features=4096),
+            torch.nn.GELU(),
+            torch.nn.Linear(in_features=4096, out_features=256)
+        ]
+        self.lins = torch.nn.Sequential(*blocks)
+        self.fc_mean = torch.nn.Linear(256, out_features)
+        self.fc_log_var = torch.nn.Linear(256, out_features)
+
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        for conv in self.convs:
+            x = conv(x)
+        # x = self.convs(x)
+        x = x.view((*x.shape[:-2], -1)).mean(dim=-1)  # Avg Pool all remaining "pixels"
+        x = self.lins(x)
+        mean = self.fc_mean(x)
+        log_var = self.fc_log_var(x)
+        return mean, log_var
+
+    def reparameterize(self, mu: torch.Tensor, logvar: torch.Tensor) -> torch.Tensor:
+        """
+        Reparameterization trick to sample from N(mu, var) from
+        N(0,1).
+        :param mu: (Tensor) Mean of the latent Gaussian [B x D]
+        :param logvar: (Tensor) Standard deviation of the latent Gaussian [B x D]
+        :return: (Tensor) [B x D]
+        """
+        std = torch.exp(0.5 * logvar)
+        eps = torch.randn_like(std)
+        out = eps * std + mu
+        # out = self.output_nonlinearities(out)
+        return out
+
+    def forward(self, x: torch.Tensor, **kwargs) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if len(x.shape) == 3:
+            x = x[:, None, :, :]
+        mu, log_var = self.encode(x)
+        z = self.reparameterize(mu, log_var)
+        return z, mu, log_var

--- a/src/models/components/encoders/__init__.py
+++ b/src/models/components/encoders/__init__.py
@@ -3,5 +3,5 @@
 # They even use the same config files... 
 from .CAE import GeneralAutoCAE as AutoCaeEncoder, GeneralManualCAE as ManualCaeEncoder
 from .VAE import GeneralAutoVAE as AutoVaeEncoder, GeneralManualVAE as ManualVaeEncoder
-from .ResNet import ResNetEncoder, VGG16 as Vgg16Encoder
+from .ResNet import ResNetEncoder, VGG16 as Vgg16Encoder, ResNetVaeEncoder
 from .VQGAN import Encoder as VqGanEncoder

--- a/src/models/facu/ResNet/__init__.py
+++ b/src/models/facu/ResNet/__init__.py
@@ -1,2 +1,3 @@
 from .resnet_weirdness import *
 from .vgg16 import *
+from .resnet_vae import *

--- a/src/models/facu/ResNet/configs/base.json
+++ b/src/models/facu/ResNet/configs/base.json
@@ -2,5 +2,8 @@
     "smoe_configs": {
         "n_kernels": 4,
         "block_size": 8
+    },
+    "loss_configs": {
+        "beta": 1e-4
     }
 }

--- a/src/models/facu/ResNet/configs/test_xai.json
+++ b/src/models/facu/ResNet/configs/test_xai.json
@@ -2,5 +2,8 @@
     "smoe_configs": {
         "n_kernels": 4,
         "block_size": 8
+    },
+    "loss_configs": {
+        "beta": 1e-4
     }
 }

--- a/src/models/facu/ResNet/resnet_vae.py
+++ b/src/models/facu/ResNet/resnet_vae.py
@@ -1,0 +1,61 @@
+import copy
+import json
+import os
+from typing import Any, Dict, Tuple, Union
+import torch
+
+from src.models.components.decoders import SmoeDecoder
+from src.models.components.encoders import ResNetVaeEncoder
+from src.models.base_model import SmoeModel
+
+__all__ = [
+    "ResNetVae"
+]
+
+
+class ResNetVae(SmoeModel):
+    _saves_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "saves")
+    def __init__(self, config_path: str):
+        try:
+            # First assume that the config_path is a relative or absolute path that's findable
+            file = open(config_path, "r")
+        except FileNotFoundError:
+            # Then try to find it in the folder where the model is saved
+            file = open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs", config_path), "r")
+        super().__init__()
+        model_configs: Dict[str] = json.load(file)
+        n_kernels = model_configs["smoe_configs"]["n_kernels"]
+        block_size = model_configs["smoe_configs"]["block_size"]
+        self.n_kernels = n_kernels
+        self.block_size = block_size
+        self._cfg = copy.deepcopy(model_configs)
+        self.encoder = ResNetVaeEncoder(in_channels=1, out_features=7*n_kernels)
+        self.decoder = SmoeDecoder(n_kernels, block_size)
+        self.beta = model_configs["loss_configs"]["beta"]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        z, mu, log_var = self.encoder(x)
+        x = self.decoder(z)
+        return x, z, mu, log_var
+
+    def reconstruct_input(self, input: torch.Tensor) -> torch.Tensor:
+        # Need to go through the __call__ method for hooks to work properly
+        return self(input)[0]
+    
+    def loss(self, inputs: torch.Tensor, output: Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor], extra_information: torch.Tensor) -> Dict[str, Union[torch.Tensor, Any]]:
+        """Loss functions are made on a model by model basis. The trainers will just feed the whole output of the 
+        model's forward function into the model's loss function, so you have control over what you need.
+
+        Args:
+            input (torch.Tensor): the input to the model
+            output (torch.Tensor): the full output of the model
+
+        Returns:
+            torch.Tensor: the loss
+        """
+        y, z, mu, log_var = output
+        true_z = extra_information
+        recons_loss = torch.nn.functional.mse_loss(y, inputs)
+        kld_loss = torch.mean(-0.5 * torch.sum(1 + log_var - mu ** 2 - log_var.exp(), dim = 1), dim = 0)
+        total_loss = recons_loss + self.beta*kld_loss
+        return total_loss, {"KLDiv Loss": kld_loss.item(), "Reconstruction Loss": recons_loss.item()}

--- a/src/models/facu/__init__.py
+++ b/src/models/facu/__init__.py
@@ -1,4 +1,4 @@
 from .VAE import VariationalAutoencoder
 from .CAE import ConvolutionalAutoencoder
-from .ResNet import ResNetWeirdness as ResNet, Vgg16
+from .ResNet import ResNetWeirdness as ResNet, Vgg16, ResNetVae
 from .VQ_GAN import VQVAE as VqVae


### PR DESCRIPTION
example implementation of a new model

first commit implements the model and adapts __init__ files so that it can be imported from the top level of the "models" module.

second commit adapts the configuration of the model family to include a new parameter for the loss function (gets ignored by models that do not use it)

third commit fixes a bug that happens with VAE models since their output is a tuple of 4 elements instead of just a tensor.